### PR TITLE
fix 'file://' prefix for ramuda invoke payload

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [0.1.409] - 2017-07-03
+### Fixed
+- fix 'file://' prefix for ramuda invoke payload (#246)
+
+## [0.1.409] - 2017-07-03
 ### Added
 - use roleARN for kumo delete, too (#162)
 

--- a/gcdt/ramuda_core.py
+++ b/gcdt/ramuda_core.py
@@ -1124,9 +1124,9 @@ def invoke(awsclient, function_name, payload, invocation_type=None,
     client_lambda = awsclient.get_client('lambda')
     if invocation_type is None:
         invocation_type = 'RequestResponse'
-    if payload.startswith('file:/'):
+    if payload.startswith('file://'):
         log.debug('reading payload from file: %s' % payload)
-        with open(payload[6:], 'r') as pfile:
+        with open(payload[7:], 'r') as pfile:
             payload = pfile.read()
 
     if version:

--- a/tests/test_ramuda_aws.py
+++ b/tests/test_ramuda_aws.py
@@ -817,7 +817,7 @@ def test_invoke_payload_from_file(awsclient, vendored_folder, temp_lambda):
     role_arn = temp_lambda[2]
     payload_file = create_tempfile('{"ramuda_action": "ping"}')
 
-    response = invoke(awsclient, lambda_name, payload='file:/%s' % payload_file)
+    response = invoke(awsclient, lambda_name, payload='file://%s' % payload_file)
     assert response == '"alive"'
 
     # cleanup


### PR DESCRIPTION
## Description/Comments


## Contributor License Agreement

gcdt is an open-source project that is licensed very permissively (see LICENSE). This means that software, and other contributions to the project are released to the public to be freely used, modified, remixed, and even sold without anyone’s permission. In order to protect this freedom, contributors must agree to waive their rights to their contributions BEFORE contributing them.

By submitting a pull request to gcdt you agree to this Contributor License Agreement, you are waiving your rights to the intellectual property that you contribute to the gcdt project. You agree to put your contribution under MIT license.
